### PR TITLE
修复is_valid_proxy函数的bug，add: 站大爷crawler

### DIFF
--- a/proxypool/crawlers/__init__.py
+++ b/proxypool/crawlers/__init__.py
@@ -1,5 +1,6 @@
 import pkgutil
 from .base import BaseCrawler
+from .public.zhandaye import ZhandayeDetailCrawler
 import inspect
 
 
@@ -9,6 +10,8 @@ for loader, name, is_pkg in pkgutil.walk_packages(__path__):
     module = loader.find_module(name).load_module(name)
     for name, value in inspect.getmembers(module):
         globals()[name] = value
-        if inspect.isclass(value) and issubclass(value, BaseCrawler) and value is not BaseCrawler:
+        if inspect.isclass(value) and issubclass(value, BaseCrawler) \
+                and value is not ZhandayeDetailCrawler \
+                and value is not BaseCrawler:
             classes.append(value)
 __all__ = __ALL__ = classes

--- a/proxypool/crawlers/__init__.py
+++ b/proxypool/crawlers/__init__.py
@@ -3,15 +3,13 @@ from .base import BaseCrawler
 from .public.zhandaye import ZhandayeDetailCrawler
 import inspect
 
-
 # load classes subclass of BaseCrawler
 classes = []
 for loader, name, is_pkg in pkgutil.walk_packages(__path__):
     module = loader.find_module(name).load_module(name)
     for name, value in inspect.getmembers(module):
         globals()[name] = value
-        if inspect.isclass(value) and issubclass(value, BaseCrawler) \
-                and value is not ZhandayeDetailCrawler \
-                and value is not BaseCrawler:
+        if inspect.isclass(value) and issubclass(value, BaseCrawler) and value is not BaseCrawler \
+                and not getattr(value, 'ignore', False):
             classes.append(value)
 __all__ = __ALL__ = classes

--- a/proxypool/crawlers/public/zhandaye.py
+++ b/proxypool/crawlers/public/zhandaye.py
@@ -1,0 +1,58 @@
+from pyquery import PyQuery as pq
+from proxypool.schemas.proxy import Proxy
+from proxypool.crawlers.base import BaseCrawler
+from loguru import logger
+
+
+BASE_URL = 'https://www.zdaye.com/dayProxy/{page}.html'
+MAX_PAGE = 5
+
+class ZhandayeCrawler(BaseCrawler):
+    """
+    zhandaye crawler, https://www.zdaye.com/dayProxy/
+    """
+    urls = [BASE_URL.format(page=page) for page in range(1, MAX_PAGE)]
+
+    def crawl(self):
+        for url in self.urls:
+            logger.info(f'fetching {url}')
+            if not self.headers:
+                html = self.fetch(url)
+            else:
+                html = self.fetch(url, headers=self.headers)
+            self.parse(html)
+
+    def parse(self, html):
+        """
+        parse html file to get proxies
+        :return:
+        """
+        doc = pq(html)
+        for item in doc('#J_posts_list .thread_item div div p a').items():
+            post = 'https://www.zdaye.com' + item.attr('href')
+            logger.info(f'get detail url: {post}')
+            ZhandayeDetailCrawler(post).crawl()
+
+
+class ZhandayeDetailCrawler(BaseCrawler):
+    urls = []
+
+    def __init__(self, url):
+        self.urls.append(url)
+        super().__init__()
+
+    def parse(self, html):
+        doc = pq(html)
+        trs = doc('.cont br').items()
+        for tr in trs:
+            line = tr[0].tail
+            host = line.split(':')[0]
+            port = line.split(':')[1][:4]
+            yield Proxy(host=host, port=port)
+
+
+
+if __name__ == '__main__':
+    crawler = ZhandayeCrawler()
+    for proxy in crawler.crawl():
+        print(proxy)

--- a/proxypool/crawlers/public/zhandaye.py
+++ b/proxypool/crawlers/public/zhandaye.py
@@ -36,6 +36,7 @@ class ZhandayeCrawler(BaseCrawler):
 
 class ZhandayeDetailCrawler(BaseCrawler):
     urls = []
+    ignore = True
 
     def __init__(self, url):
         self.urls.append(url)

--- a/proxypool/utils/proxy.py
+++ b/proxypool/utils/proxy.py
@@ -1,14 +1,30 @@
 from proxypool.schemas import Proxy
-import re
 
 
 def is_valid_proxy(data):
-    """
-    is data is valid proxy format
-    :param data:
-    :return:
-    """
-    return re.match('\d+\.\d+\.\d+\.\d+\:\d+', data)
+    if data.__contains__(':'):
+        ip = data.split(':')[0]
+        port = data.split(':')[1]
+        return is_ip_valid(ip) and is_port_valid(port)
+    else:
+        return is_ip_valid(data)
+
+
+def is_ip_valid(ip):
+    a = ip.split('.')
+    if len(a) != 4:
+        return False
+    for x in a:
+        if not x.isdigit():
+            return False
+        i = int(x)
+        if i < 0 or i > 255:
+            return False
+    return True
+
+
+def is_port_valid(port):
+    return port.isdigit()
 
 
 def convert_proxy_or_proxies(data):


### PR DESCRIPTION
1.is_valid_proxy函数单纯的正则表达式在遇到 215.51.53.5:456@ 就会有问题，本次pr修复了这个问题
2.新增了站大爷的crawler，因为站大爷是在嵌套的二级页面才能获取到代理ip，所以复写了BaseCrawler.crawl()方法，具体可以参考diff