### PR TITLE
解决bug：ZhandayeCrawler没有headers属性

### DIFF
--- a/proxypool/crawlers/base.py
+++ b/proxypool/crawlers/base.py
@@ -6,7 +6,7 @@ from loguru import logger
 class BaseCrawler(object):
     urls = []
     
-    @retry(stop_max_attempt_number=3, retry_on_result=lambda x: x is None)
+    @retry(stop_max_attempt_number=3, retry_on_result=lambda x: x is None, wait_fixed=2000)
     def fetch(self, url, **kwargs):
         try:
             response = requests.get(url, **kwargs)

--- a/proxypool/crawlers/public/zhandaye.py
+++ b/proxypool/crawlers/public/zhandaye.py
@@ -13,13 +13,14 @@ class ZhandayeCrawler(BaseCrawler):
     """
     urls = [BASE_URL.format(page=page) for page in range(1, MAX_PAGE)]
 
+    headers = {
+        'User-Agent': 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36'
+    }
+
     def crawl(self):
         for url in self.urls:
             logger.info(f'fetching {url}')
-            if not self.headers:
-                html = self.fetch(url)
-            else:
-                html = self.fetch(url, headers=self.headers)
+            html = self.fetch(url, headers=self.headers)
             self.parse(html)
 
     def parse(self, html):


### PR DESCRIPTION
解决bug: AttributeError: 'ZhandayeCrawler' object has no attribute 'headers'

```
2020-07-10 23:11:43.754 | INFO     | public.zhandaye:crawl:18 - fetching https://www.zdaye.com/dayProxy/1.html
2020-07-10 23:11:43.754 | ERROR    | proxypool.scheduler:run_getter:48 - An error has been caught in function 'run_getter', process 'MainProcess' (8
), thread 'MainThread' (140622998312768):
Traceback (most recent call last):

  File "run.py", line 12, in <module>
    getattr(Scheduler(), f'run_{args.processor}')()
            └ <class 'proxypool.scheduler.Scheduler'>

> File "/app/proxypool/scheduler.py", line 48, in run_getter
    getter.run()
    │      └ <function Getter.run at 0x7fe556e726a8>
    └ <proxypool.processors.getter.Getter object at 0x7fe554519550>

  File "/app/proxypool/processors/getter.py", line 36, in run
    for proxy in crawler.crawl():
        │        │       └ <function ZhandayeCrawler.crawl at 0x7fe556e72730>
        │        └ <public.zhandaye.ZhandayeCrawler object at 0x7fe554519588>
        └ Proxy(host='163.125.222.195', port='8088')

  File "/app/proxypool/crawlers/public/zhandaye.py", line 19, in crawl
    if not self.headers:
           └ <public.zhandaye.ZhandayeCrawler object at 0x7fe554519588>

AttributeError: 'ZhandayeCrawler' object has no attribute 'headers'
```