### PR TITLE
getter引入协程，aiohttp中的session优化

### DIFF
--- a/proxypool/crawlers/base.py
+++ b/proxypool/crawlers/base.py
@@ -1,32 +1,41 @@
+import asyncio
+import aiohttp
 from retrying import retry
-import requests
 from loguru import logger
 from proxypool.setting import GET_TIMEOUT
 
 
 class BaseCrawler(object):
     urls = []
-    
+
+    def __init__(self):
+        self.loop = asyncio.get_event_loop()
+
     @retry(stop_max_attempt_number=3, retry_on_result=lambda x: x is None, wait_fixed=2000)
-    def fetch(self, url, **kwargs):
+    async def fetch(self, session, url, **kwargs):
         try:
             kwargs.setdefault('timeout', GET_TIMEOUT)
-            kwargs.setdefault('verify', False)
-            response = requests.get(url, **kwargs)
-            if response.status_code == 200:
-                response.encoding = 'utf-8'
-                return response.text
-        except requests.ConnectionError:
+            async with session.get(url, **kwargs) as response:
+                if response.status == 200:
+                    response.encoding = 'utf-8'
+                    return await response.text()
+        except aiohttp.ClientConnectionError:
             return
-    
+
     @logger.catch
-    def crawl(self):
+    async def crawl(self):
         """
         crawl main method
         """
-        for url in self.urls:
-            logger.info(f'fetching {url}')
-            html = self.fetch(url)
-            for proxy in self.parse(html):
-                logger.info(f'fetched proxy {proxy.string()} from {url}')
-                yield proxy
+        proxies = []
+        async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=False)) as session:
+            tasks = [self.fetch(session, url) for url in self.urls]
+            results = await asyncio.gather(*tasks)
+            for result in results:
+                if result:
+                    for proxy in self.parse(result):
+                        proxies.append(proxy)
+            return proxies
+
+    def run(self):
+        return  self.loop.run_until_complete(self.crawl())

--- a/proxypool/crawlers/public/data5u.py
+++ b/proxypool/crawlers/public/data5u.py
@@ -1,3 +1,5 @@
+import asyncio
+import aiohttp
 from pyquery import PyQuery as pq
 from proxypool.schemas.proxy import Proxy
 from proxypool.crawlers.base import BaseCrawler
@@ -11,23 +13,23 @@ class Data5UCrawler(BaseCrawler):
     data5u crawler, http://www.data5u.com
     """
     urls = [BASE_URL]
-    
+
     headers = {
         'User-Agent': 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36'
     }
 
     @logger.catch
-    def crawl(self):
-        """
-        crawl main method
-        """
-        for url in self.urls:
-            logger.info(f'fetching {url}')
-            html = self.fetch(url, headers=self.headers)
-            for proxy in self.parse(html):
-                logger.info(f'fetched proxy {proxy.string()} from {url}')
-                yield proxy
-    
+    async def crawl(self):
+        proxies = []
+        async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=False)) as session:
+            tasks = [self.fetch(session, url, headers=self.headers) for url in self.urls]
+            results = await asyncio.gather(*tasks)
+            for result in results:
+                if result:
+                    for proxy in self.parse(result):
+                        proxies.append(proxy)
+            return proxies
+
     def parse(self, html):
         """
         parse html file to get proxies

--- a/proxypool/processors/getter.py
+++ b/proxypool/processors/getter.py
@@ -8,7 +8,7 @@ class Getter(object):
     """
     getter of proxypool
     """
-    
+
     def __init__(self):
         """
         init db and crawlers
@@ -16,14 +16,14 @@ class Getter(object):
         self.redis = RedisClient()
         self.crawlers_cls = crawlers_cls
         self.crawlers = [crawler_cls() for crawler_cls in self.crawlers_cls]
-    
+
     def is_full(self):
         """
         if proxypool if full
         return: bool
         """
         return self.redis.count() >= PROXY_NUMBER_MAX
-    
+
     @logger.catch
     def run(self):
         """
@@ -34,8 +34,13 @@ class Getter(object):
             return
         for crawler in self.crawlers:
             logger.info(f'crawler {crawler} to get proxy')
-            for proxy in crawler.crawl():
-                self.redis.add(proxy)
+            proxies = crawler.run()
+            if proxies:
+                for proxy in proxies:
+                    self.redis.add(proxy)
+                logger.info(f'crawled {len(proxies)} proxies from {crawler}')
+            else:
+                logger.debug(f'cannot crawl proxies from {crawler}')
 
 
 if __name__ == '__main__':

--- a/proxypool/processors/tester.py
+++ b/proxypool/processors/tester.py
@@ -23,49 +23,48 @@ class Tester(object):
     """
     tester for testing proxies in queue
     """
-    
+
     def __init__(self):
         """
         init redis
         """
         self.redis = RedisClient()
         self.loop = asyncio.get_event_loop()
-    
-    async def test(self, proxy: Proxy):
+
+    async def test(self, session, proxy: Proxy):
         """
         test single proxy
         :param proxy: Proxy object
         :return:
         """
-        async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=False)) as session:
-            try:
-                logger.debug(f'testing {proxy.string()}')
-                # if TEST_ANONYMOUS is True, make sure that
-                # the proxy has the effect of hiding the real IP
-                if TEST_ANONYMOUS:
-                    url = 'https://httpbin.org/ip'
-                    async with session.get(url, timeout=TEST_TIMEOUT) as response:
-                        resp_json = await response.json()
-                        origin_ip = resp_json['origin']
-                    async with session.get(url, proxy=f'http://{proxy.string()}', timeout=TEST_TIMEOUT) as response:
-                        resp_json = await response.json()
-                        anonymous_ip = resp_json['origin']
-                    assert origin_ip != anonymous_ip
-                    assert proxy.host == anonymous_ip
-                async with session.get(TEST_URL, proxy=f'http://{proxy.string()}', timeout=TEST_TIMEOUT,
-                                       allow_redirects=False) as response:
-                    if response.status in TEST_VALID_STATUS:
-                        self.redis.max(proxy)
-                        logger.debug(f'proxy {proxy.string()} is valid, set max score')
-                    else:
-                        self.redis.decrease(proxy)
-                        logger.debug(f'proxy {proxy.string()} is invalid, decrease score')
-            except EXCEPTIONS:
-                self.redis.decrease(proxy)
-                logger.debug(f'proxy {proxy.string()} is invalid, decrease score')
-    
+        try:
+            logger.debug(f'testing {proxy.string()}')
+            # if TEST_ANONYMOUS is True, make sure that
+            # the proxy has the effect of hiding the real IP
+            if TEST_ANONYMOUS:
+                url = 'https://httpbin.org/ip'
+                async with session.get(url, timeout=TEST_TIMEOUT) as response:
+                    resp_json = await response.json()
+                    origin_ip = resp_json['origin']
+                async with session.get(url, proxy=f'http://{proxy.string()}', timeout=TEST_TIMEOUT) as response:
+                    resp_json = await response.json()
+                    anonymous_ip = resp_json['origin']
+                assert origin_ip != anonymous_ip
+                assert proxy.host == anonymous_ip
+            async with session.get(TEST_URL, proxy=f'http://{proxy.string()}', timeout=TEST_TIMEOUT,
+                                    allow_redirects=False) as response:
+                if response.status in TEST_VALID_STATUS:
+                    self.redis.max(proxy)
+                    logger.debug(f'proxy {proxy.string()} is valid, set max score')
+                else:
+                    self.redis.decrease(proxy)
+                    logger.debug(f'proxy {proxy.string()} is invalid, decrease score')
+        except EXCEPTIONS:
+            self.redis.decrease(proxy)
+            logger.debug(f'proxy {proxy.string()} is invalid, decrease score')
+
     @logger.catch
-    def run(self):
+    async def main(self):
         """
         test main method
         :return:
@@ -75,14 +74,18 @@ class Tester(object):
         count = self.redis.count()
         logger.debug(f'{count} proxies to test')
         cursor = 0
-        while True:
-            logger.debug(f'testing proxies use cursor {cursor}, count {TEST_BATCH}')
-            cursor, proxies = self.redis.batch(cursor, count=TEST_BATCH)
-            if proxies:
-                tasks = [self.test(proxy) for proxy in proxies]
-                self.loop.run_until_complete(asyncio.wait(tasks))
-            if not cursor:
-                break
+        async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=False)) as session:
+            while True:
+                logger.debug(f'testing proxies use cursor {cursor}, count {TEST_BATCH}')
+                cursor, proxies = self.redis.batch(cursor, count=TEST_BATCH)
+                if proxies:
+                    tasks = [self.test(session, proxy) for proxy in proxies]
+                    await asyncio.gather(*tasks)
+                if not cursor:
+                    break
+
+    def run(self):
+        self.loop.run_until_complete(self.main())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
1. crawler 中的爬取任务改用协程并发完成，由于异步方式，无法用 logger 记录当前正在爬取的网页了
2. data5u.py 中重写的爬取方法也做了相应修改
3. 原 tester 中，测试每个 proxy 都创建了一个 aiohttp.ClientSession，这有点浪费没有复用 session 的连接池，所以我增加了一个 main 方法用一个 session 处理了所有的代理测试。