### PR TITLE
fix pip version is too low causing docker packaging to fail

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.6
 WORKDIR /app
 COPY . .
-RUN pip install -r requirements.txt
+RUN pip install -U pip && pip install -r requirements.txt -i https://pypi.tuna.tsinghua.edu.cn/simple/
 VOLUME ["/app/proxypool/crawlers/private"]
 CMD ["supervisord", "-c", "supervisord.conf"]


### PR DESCRIPTION
```diff
- RUN pip install -r requirements.txt
+ RUN pip install -U pip && pip install -r requirements.txt -i https://pypi.tuna.tsinghua.edu.cn/simple/
```