### PR TITLE
requirements.txt modified

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,8 +11,7 @@ redis>=3.5.3,<4.0.0
 lxml>=4.6.5,<5.0.0
 fake_headers>=1.0.2,<2.0.0
 maxminddb_geolite2==2018.703
-gevent>=21.1.0,<22.0.0
+gevent>=21.8.0,<22.0.0
 tornado>=6.0,<7.0
-meinheld>=1.0.0,<2.0.0
 itsdangerous==0.24
 MarkupSafe<2.1.0


### PR DESCRIPTION
当我试图调用docker-compose -f build.yaml up时候我先得到了一个错误->
```Bash
Error compiling Cython file:
      ------------------------------------------------------------
      ...
      cdef load_traceback
      cdef Waiter
      cdef wait
      cdef iwait
      cdef reraise
      cpdef GEVENT_CONFIG
            ^
      ------------------------------------------------------------
      
      src/gevent/_gevent_cgreenlet.pxd:182:6: Variables cannot be declared with 'cpdef'. Use 'cdef' instead.
      Compiling src/gevent/greenlet.py because it changed.
```
然后我去gevent的github仓库查看issue，发现将gevent设置为>=21.8.0,<22.0.0即可，于是我修改为了gevent>=21.8.0,<22.0.0。
这时我又跑了docker-compose指令得到了新的错误
```Bash
The conflict is caused by:
    gevent 21.8.0 depends on greenlet<2.0 and >=1.1.0; platform_python_implementation == "CPython"
    meinheld 1.0.0 depends on greenlet<0.5 and >=0.4.5
```
于是我移除了meinheld这个下载选项，因为我发现meinheld已经很长时间没更新了，并且对greenlet的支持版本很低。但是我不知道我这样移除了是否会影响代码本身什么功能？
如果有什么错误操作希望您能指正！(还是新手正在学习中，如有错误请见谅。)
期待您的回复！