### PR TITLE
fix docip bug & add support for python 3.11

### DIFF
--- a/proxypool/crawlers/public/docip.py
+++ b/proxypool/crawlers/public/docip.py
@@ -25,7 +25,7 @@ class DocipCrawler(BaseCrawler):
             proxy_list = result['data']
             for proxy_item in proxy_list:
                 host = proxy_item['ip']
-                port = proxy_item['port']
+                port = host.split(':')[-1]
                 yield Proxy(host=host, port=port)
         except json.JSONDecodeError:
             print("json.JSONDecodeError")

--- a/proxypool/processors/tester.py
+++ b/proxypool/processors/tester.py
@@ -82,7 +82,7 @@ class Tester(object):
             logger.debug(f'testing proxies use cursor {cursor}, count {TEST_BATCH}')
             cursor, proxies = self.redis.batch(cursor, count=TEST_BATCH)
             if proxies:
-                tasks = [self.test(proxy) for proxy in proxies]
+                tasks = [self.loop.create_task(self.test(proxy)) for proxy in proxies]
                 self.loop.run_until_complete(asyncio.wait(tasks))
             if not cursor:
                 break

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ redis>=3.5.3,<4.0.0
 lxml>=4.6.5,<5.0.0
 fake_headers>=1.0.2,<2.0.0
 maxminddb_geolite2==2018.703
-gevent>=21.8.0,<22.0.0
+gevent>=21.8.0,<24.0.0
 tornado>=6.0,<7.0
 itsdangerous==0.24
 MarkupSafe<2.1.0


### PR DESCRIPTION
**1. Fix: docip crawler bug**

As mentioned in issue #204 , the bug in docip crawler will block the getter thread and thus cannot get proxy normally.
This PR is to fix the host:port parse logic in `proxypool/crawlers/public/docip.py`.

**2. Add: support for python3.11**
**2.1 update requirements.txt**
After python3.11, there is a **variable name change for CFrame**, which will cause the building failure when installing old version of **gevent**.
e.g. 
```
In file included from src/gevent/_greenlet_primitives.c:1207:
      /tmp/pip-install-cox1kni6/gevent_420af8e5de034ff09b7c37217c08be8a/deps/greenlet/greenlet.h:42:5: error: unknown type name 'CFrame'
         42 |     CFrame* cframe;
            |     ^
      1 error generated.
```
Check this commit in CPython: [[bpo-45431]Rename CFrame to _PyCFrame in the C API](https://github.com/python/cpython/commit/7496f9587306772b56ed074092c020f3ef16bf95)
They rename it from `CFrame *cframe;` to `_PyCFrame *cframe;` and this results in a large number of packages needing to be modified to adapt to CPython updates.
As Python 3.11 has been available for over a year, and Python 3.12 has been available for over two months, I think it's time to bump the requirements to support newer version of Python.

**2.2 update proxypool/processors/tester.py**
After python3.11, directly passing coroutines to asyncio loop is forbidden, which will cause TypeError on `proxypool/processors/tester.py:85`
```python
 tasks = [self.test(proxy) for proxy in proxies]
``` 
as 
```
  File "/usr/lib/python3.11/asyncio/tasks.py", line 415, in wait
    raise TypeError("Passing coroutines is forbidden, use tasks explicitly.")

TypeError: Passing coroutines is forbidden, use tasks explicitly.
```
I changed it to newer style for supporting newer Python version.
This is also mentioned in issue #201.

I tested these changes under Python 3.11 & Python 3.12 environment and verified they are running steadily.

Regards,
B1ACK917