### PR TITLE
fix: use constant-time comparison for auth token (CWE-208)

### DIFF
--- a/proxypool/processors/server.py
+++ b/proxypool/processors/server.py
@@ -1,3 +1,4 @@
+import hmac
 from flask import Flask, g, request
 from proxypool.exceptions import PoolEmptyException
 from proxypool.storages.redis import RedisClient
@@ -22,7 +23,7 @@ def auth_required(func):
         else:
             return {"message": "Please provide an API key in header"}, 400
         # Check if API key is correct and valid
-        if request.method == "GET" and api_key == API_KEY:
+        if request.method == "GET" and hmac.compare_digest(api_key, API_KEY):
             return func(*args, **kwargs)
         else:
             return {"message": "The provided API key is not valid"}, 403


### PR DESCRIPTION
## Summary
Fixes #226 — replaces timing-vulnerable `==` comparison with constant-time `hmac.compare_digest`.

## Changes
- Replace direct string comparison with constant-time comparison for API key
- No behavioral change for valid authentication flows

## CWE Reference
- **CWE-208**: Observable Timing Discrepancy
- Uses stdlib only (`hmac`) — no new dependencies

---
*Found by [SpiderShield](https://github.com/teehooai/spidershield) security scanner*