### PR TITLE
fix: resolve core runtime bugs (tester event loop, /random 500, scheduler crash)

### DIFF
--- a/proxypool/processors/tester.py
+++ b/proxypool/processors/tester.py
@@ -5,7 +5,8 @@ from proxypool.schemas import Proxy
 from proxypool.storages.redis import RedisClient
 from proxypool.setting import TEST_TIMEOUT, TEST_BATCH, TEST_URL, TEST_VALID_STATUS, TEST_ANONYMOUS, \
     TEST_DONT_SET_MAX_SCORE
-from aiohttp import ClientProxyConnectionError, ServerDisconnectedError, ClientOSError, ClientHttpProxyError
+from aiohttp import ClientProxyConnectionError, ServerDisconnectedError, ClientOSError, ClientHttpProxyError, \
+    ClientResponseError, ContentTypeError
 from asyncio import TimeoutError
 from proxypool.testers import __all__ as testers_cls
 
@@ -16,6 +17,8 @@ EXCEPTIONS = (
     ServerDisconnectedError,
     ClientOSError,
     ClientHttpProxyError,
+    ClientResponseError,
+    ContentTypeError,
     AssertionError
 )
 
@@ -30,83 +33,102 @@ class Tester(object):
         init redis
         """
         self.redis = RedisClient()
-        self.loop = asyncio.get_event_loop()
         self.testers_cls = testers_cls
         self.testers = [tester_cls() for tester_cls in self.testers_cls]
 
-    async def test(self, proxy: Proxy):
+    async def test(self, proxy: Proxy, session: aiohttp.ClientSession):
         """
         test single proxy
         :param proxy: Proxy object
+        :param session: shared aiohttp session
         :return:
         """
-        async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=False)) as session:
-            try:
-                logger.debug(f'testing {proxy.string()}')
-                # if TEST_ANONYMOUS is True, make sure that
-                # the proxy has the effect of hiding the real IP
-                # logger.debug(f'TEST_ANONYMOUS {TEST_ANONYMOUS}')
-                if TEST_ANONYMOUS:
-                    url = 'https://httpbin.org/ip'
-                    async with session.get(url, timeout=TEST_TIMEOUT) as response:
-                        resp_json = await response.json()
-                        origin_ip = resp_json['origin']
-                        # logger.debug(f'origin ip is {origin_ip}')
-                    async with session.get(url, proxy=f'http://{proxy.string()}', timeout=TEST_TIMEOUT) as response:
-                        resp_json = await response.json()
-                        anonymous_ip = resp_json['origin']
-                        logger.debug(f'anonymous ip is {anonymous_ip}')
-                    assert origin_ip != anonymous_ip
-                    assert proxy.host == anonymous_ip
-                async with session.get(TEST_URL, proxy=f'http://{proxy.string()}', timeout=TEST_TIMEOUT,
-                                       allow_redirects=False) as response:
-                    if response.status in TEST_VALID_STATUS:
-                        if TEST_DONT_SET_MAX_SCORE:
-                            logger.debug(
-                                f'proxy {proxy.string()} is valid, remain current score')
-                        else:
-                            self.redis.max(proxy)
-                            logger.debug(
-                                f'proxy {proxy.string()} is valid, set max score')
-                    else:
-                        self.redis.decrease(proxy)
+        try:
+            logger.debug(f'testing {proxy.string()}')
+            # if TEST_ANONYMOUS is True, make sure that
+            # the proxy has the effect of hiding the real IP
+            # logger.debug(f'TEST_ANONYMOUS {TEST_ANONYMOUS}')
+            if TEST_ANONYMOUS:
+                url = 'https://httpbin.org/ip'
+                async with session.get(url, timeout=TEST_TIMEOUT) as response:
+                    resp_json = await response.json()
+                    origin_ip = resp_json['origin']
+                    # logger.debug(f'origin ip is {origin_ip}')
+                async with session.get(url, proxy=f'http://{proxy.string()}', timeout=TEST_TIMEOUT) as response:
+                    resp_json = await response.json()
+                    anonymous_ip = resp_json['origin']
+                    logger.debug(f'anonymous ip is {anonymous_ip}')
+                assert origin_ip != anonymous_ip
+                assert proxy.host == anonymous_ip
+            async with session.get(TEST_URL, proxy=f'http://{proxy.string()}', timeout=TEST_TIMEOUT,
+                                   allow_redirects=False) as response:
+                if response.status in TEST_VALID_STATUS:
+                    if TEST_DONT_SET_MAX_SCORE:
                         logger.debug(
-                            f'proxy {proxy.string()} is invalid, decrease score')
-                # if independent tester class found, create new set of storage and do the extra test
-                for tester in self.testers:
-                    key = tester.key
-                    if self.redis.exists(proxy, key):
-                        test_url = tester.test_url
-                        headers = tester.headers()
-                        cookies = tester.cookies()
-                        async with session.get(test_url, proxy=f'http://{proxy.string()}',
-                                               timeout=TEST_TIMEOUT,
-                                               headers=headers,
-                                               cookies=cookies,
-                                               allow_redirects=False) as response:
-                            resp_text = await response.text()
-                            is_valid = await tester.parse(resp_text, test_url, proxy.string())
-                            if is_valid:
-                                if tester.test_dont_set_max_score:
-                                    logger.info(
-                                        f'key[{key}] proxy {proxy.string()} is valid, remain current score')
-                                else:
-                                    self.redis.max(
-                                        proxy, key, tester.proxy_score_max)
-                                    logger.info(
-                                        f'key[{key}] proxy {proxy.string()} is valid, set max score')
-                            else:
-                                self.redis.decrease(
-                                    proxy, tester.key, tester.proxy_score_min)
+                            f'proxy {proxy.string()} is valid, remain current score')
+                    else:
+                        self.redis.max(proxy)
+                        logger.debug(
+                            f'proxy {proxy.string()} is valid, set max score')
+                else:
+                    self.redis.decrease(proxy)
+                    logger.debug(
+                        f'proxy {proxy.string()} is invalid, decrease score')
+            # if independent tester class found, create new set of storage and do the extra test
+            for tester in self.testers:
+                key = tester.key
+                if self.redis.exists(proxy, key):
+                    test_url = tester.test_url
+                    headers = tester.headers()
+                    cookies = tester.cookies()
+                    async with session.get(test_url, proxy=f'http://{proxy.string()}',
+                                           timeout=TEST_TIMEOUT,
+                                           headers=headers,
+                                           cookies=cookies,
+                                           allow_redirects=False) as response:
+                        resp_text = await response.text()
+                        is_valid = await tester.parse(resp_text, test_url, proxy.string())
+                        if is_valid:
+                            if tester.test_dont_set_max_score:
                                 logger.info(
-                                    f'key[{key}] proxy {proxy.string()} is invalid, decrease score')
+                                    f'key[{key}] proxy {proxy.string()} is valid, remain current score')
+                            else:
+                                self.redis.max(
+                                    proxy, key, tester.proxy_score_max)
+                                logger.info(
+                                    f'key[{key}] proxy {proxy.string()} is valid, set max score')
+                        else:
+                            self.redis.decrease(
+                                proxy, tester.key, tester.proxy_score_min)
+                            logger.info(
+                                f'key[{key}] proxy {proxy.string()} is invalid, decrease score')
 
-            except EXCEPTIONS:
-                self.redis.decrease(proxy)
-                [self.redis.decrease(proxy, tester.key, tester.proxy_score_min)
-                 for tester in self.testers]
+        except EXCEPTIONS:
+            self.redis.decrease(proxy)
+            [self.redis.decrease(proxy, tester.key, tester.proxy_score_min)
+             for tester in self.testers]
+            logger.debug(
+                f'proxy {proxy.string()} is invalid, decrease score')
+
+    async def run_tests(self):
+        """
+        test all proxies in batches, reusing a single aiohttp session
+        :return:
+        """
+        count = self.redis.count()
+        logger.debug(f'{count} proxies to test')
+        cursor = 0
+        connector = aiohttp.TCPConnector(ssl=False, limit=TEST_BATCH)
+        async with aiohttp.ClientSession(connector=connector) as session:
+            while True:
                 logger.debug(
-                    f'proxy {proxy.string()} is invalid, decrease score')
+                    f'testing proxies use cursor {cursor}, count {TEST_BATCH}')
+                cursor, proxies = self.redis.batch(cursor, count=TEST_BATCH)
+                if proxies:
+                    tasks = [self.test(proxy, session) for proxy in proxies]
+                    await asyncio.gather(*tasks, return_exceptions=True)
+                if not cursor:
+                    break
 
     @logger.catch
     def run(self):
@@ -116,26 +138,29 @@ class Tester(object):
         """
         # event loop of aiohttp
         logger.info('stating tester...')
-        count = self.redis.count()
-        logger.debug(f'{count} proxies to test')
-        cursor = 0
-        while True:
-            logger.debug(
-                f'testing proxies use cursor {cursor}, count {TEST_BATCH}')
-            cursor, proxies = self.redis.batch(cursor, count=TEST_BATCH)
-            if proxies:
-                tasks = [self.loop.create_task(
-                    self.test(proxy)) for proxy in proxies]
-                self.loop.run_until_complete(asyncio.wait(tasks))
-            if not cursor:
-                break
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            loop.run_until_complete(self.run_tests())
+        finally:
+            loop.close()
 
 
 def run_tester():
     host = '96.113.165.182'
     port = '3128'
-    tasks = [tester.test(Proxy(host=host, port=port))]
-    tester.loop.run_until_complete(asyncio.wait(tasks))
+    tester = Tester()
+
+    async def _test():
+        async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=False)) as session:
+            await tester.test(Proxy(host=host, port=port), session)
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        loop.run_until_complete(_test())
+    finally:
+        loop.close()
 
 
 if __name__ == '__main__':

--- a/proxypool/scheduler.py
+++ b/proxypool/scheduler.py
@@ -129,12 +129,15 @@ class Scheduler():
             tester_process and tester_process.join()
             getter_process and getter_process.join()
             server_process and server_process.join()
-            logger.info(
-                f'tester is {"alive" if tester_process.is_alive() else "dead"}')
-            logger.info(
-                f'getter is {"alive" if getter_process.is_alive() else "dead"}')
-            logger.info(
-                f'server is {"alive" if server_process.is_alive() else "dead"}')
+            if tester_process:
+                logger.info(
+                    f'tester is {"alive" if tester_process.is_alive() else "dead"}')
+            if getter_process:
+                logger.info(
+                    f'getter is {"alive" if getter_process.is_alive() else "dead"}')
+            if server_process:
+                logger.info(
+                    f'server is {"alive" if server_process.is_alive() else "dead"}')
             logger.info('proxy terminated')
 
 

--- a/proxypool/utils/proxy.py
+++ b/proxypool/utils/proxy.py
@@ -63,7 +63,7 @@ def convert_proxy_or_proxies(data):
         if is_auth_proxy(data):
             host, port = extract_auth_proxy(data)
         else:
-            host, port = data.split(':')
+            host, port, *_ = data.split(':')
         return Proxy(host=host, port=int(port))
 
 


### PR DESCRIPTION
## 背景

这是 issue 收敛计划的 **Phase 1（核心运行期 Bug 修复）**。只修 Bug，不动依赖/功能，保证行为稳定。

## 改动内容

### 1. `/random` 返回 500 — `ValueError: too many values to unpack`
[`proxypool/utils/proxy.py`](proxypool/utils/proxy.py) 中 `convert_proxy_or_proxies` 的 **str 分支** 用了 `host, port = data.split(':')`，当 Redis 里存在形如 `ip:port:port` / 多冒号的脏数据时会抛异常，直接导致 `/random` 500。list 分支早已用 `*_` 兜底，这里对齐为 `host, port, *_ = data.split(':')`。
- Closes #218

### 2. `ENABLE_TESTER/GETTER/SERVER=false` 启动崩溃
[`proxypool/scheduler.py`](proxypool/scheduler.py) 的 `finally` 块无条件调用 `tester_process.is_alive()`，当对应进程被禁用时该变量为 `None` → `AttributeError`。改为判空后再打印状态。
- Closes #62

### 3. tester 在 Python 3.10+ 报错 / 内存增长 / fd 耗尽
[`proxypool/processors/tester.py`](proxypool/processors/tester.py)：
- 用 `asyncio.new_event_loop()` + `asyncio.gather()` 取代已弃用的 `asyncio.get_event_loop()` 与对协程调用的 `asyncio.wait()`，修复 `TypeError: Passing coroutines is forbidden, use tasks explicitly.`
- 复用**单个** `aiohttp.ClientSession`（原来每个代理都新建一个 session），并给 `TCPConnector` 设置 `limit=TEST_BATCH` 上限，缓解长跑内存增长与 Windows `too many file descriptors in select()`。
- `EXCEPTIONS` 增加 `ClientResponseError`、`ContentTypeError`，`gather(..., return_exceptions=True)`，避免 httpbin 返回非 JSON/超长 header 时出现 `Task exception was never retrieved`。
- Closes #191, Closes #119, Closes #155, Closes #208
- Related: #201

## 验证
- 三个文件 `py_compile` 通过，无 lint 错误。
- 复现验证：`convert_proxy_or_proxies('1.2.3.4:80:90')` 由「抛异常」变为返回 `1.2.3.4:80`；混合列表、正常输入均正常。

## 影响面
仅内部实现调整，API 行为、评分逻辑、配置项均不变。