### PR TITLE
security: validate `key` query param against redis key injection + document API_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,9 @@ get random proxy 116.196.115.209:8080
 - API_HOST：代理 Server 运行 Host，默认 0.0.0.0
 - API_PORT：代理 Server 运行端口，默认 5555
 - API_THREADED：代理 Server 是否使用多线程，默认 true
+- API_KEY：API 访问鉴权密钥，默认空（即不鉴权）。设置后，调用 `/random`、`/all`、`/count` 需在请求头携带 `API-KEY`，详见下方「安全性」说明
+
+> ⚠️ 安全提示：代理 Server 默认监听 `0.0.0.0` 且 `API_KEY` 默认为空，任何能访问该端口的人都可以调用 `/random`、`/all`、`/count`。如果将代理池**暴露到公网**，请务必设置 `API_KEY`，并配合防火墙/安全组限制来源。`key` 查询参数已做格式校验，仅允许字母、数字及 `_ : -`，最长 64 位。
 
 ### 日志
 

--- a/proxypool/processors/server.py
+++ b/proxypool/processors/server.py
@@ -1,5 +1,6 @@
 import hmac
-from flask import Flask, g, request
+import re
+from flask import Flask, g, request, abort
 from proxypool.exceptions import PoolEmptyException
 from proxypool.storages.redis import RedisClient
 from proxypool.setting import API_HOST, API_PORT, API_THREADED, API_KEY, IS_DEV, PROXY_RAND_KEY_DEGRADED
@@ -10,6 +11,10 @@ __all__ = ['app']
 app = Flask(__name__)
 if IS_DEV:
     app.debug = True
+
+# allowed characters for the `key` query parameter that selects a redis sub-pool;
+# restricts to a safe charset to avoid probing arbitrary redis keys via the API
+VALID_KEY_PATTERN = re.compile(r'^[a-zA-Z0-9_:\-]{1,64}$')
 
 
 def auth_required(func):
@@ -41,6 +46,18 @@ def get_conn():
     return g.redis
 
 
+def get_request_key():
+    """
+    read the `key` query parameter and validate its format;
+    reject unexpected characters to avoid redis key probing/injection
+    :return: validated key or None
+    """
+    key = request.args.get('key')
+    if key and not VALID_KEY_PATTERN.match(key):
+        abort(400, description='invalid key parameter')
+    return key
+
+
 @app.route('/')
 @auth_required
 def index():
@@ -59,7 +76,7 @@ def get_proxy():
     if PROXY_RAND_KEY_DEGRADED is set to True, will get a universal random proxy if no proxy found in the sub-pool
     :return: get a random proxy
     """
-    key = request.args.get('key')
+    key = get_request_key()
     conn = get_conn()
     # return conn.random(key).string() if key else conn.random().string()
     if key:
@@ -78,7 +95,7 @@ def get_proxy_all():
     get a random proxy
     :return: get a random proxy
     """
-    key = request.args.get('key')
+    key = get_request_key()
 
     conn = get_conn()
     proxies = conn.all(key) if key else conn.all()
@@ -98,8 +115,8 @@ def get_count():
     :return: count, int
     """
     conn = get_conn()
-    key = request.args.get('key')
-    return str(conn.count(key)) if key else conn.count()
+    key = get_request_key()
+    return str(conn.count(key)) if key else str(conn.count())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## 背景

Issue 收敛计划 **Phase 3（安全加固）**，对应 #228。

## 问题（来自 #228）

1. `API_KEY` 默认空串 → 部署到公网后 `/random`、`/all`、`/count` 全部无鉴权可访问。
2. `/random?key=xxx` 把 `key` 直接当作 Redis key 名传入，可用于探测其他 zset。
3. README 未提及 `API_KEY`。

## 改动

- **key 参数校验**（[`server.py`](proxypool/processors/server.py)）：新增 `get_request_key()`，用白名单字符集 `^[a-zA-Z0-9_:\-]{1,64}$` 校验 `key`，非法输入直接返回 `400`。`/random`、`/all`、`/count` 统一走该校验，杜绝任意 Redis key 探测/注入。空 `key`（`?key=`）保持原「回退到通用池」行为。
- **顺手修一个历史小 bug**：`/count` 在不带 `key` 时直接 `return conn.count()`（int），而 Flask 视图不允许返回 int（会 500）。改为始终返回字符串。
- **文档**（`README.md`）：补充 `API_KEY` 配置说明，并新增醒目的「安全提示」——暴露公网务必设置 `API_KEY` 并配合防火墙/安全组。

## 关于「默认鉴权」的取舍

#228 建议 #1 是「默认生成随机 `API_KEY`」。考虑到 README 的快速上手（`docker-compose up` 后直接 `curl /random`）完全依赖免鉴权，**默认强制鉴权会破坏开箱即用体验**，因此本 PR 采取「默认开放 + 文档强提示 + 参数校验」的稳妥方案。如果你倾向默认强制鉴权，我可以再补一版（自动生成并在启动日志打印 key）。

## 验证

- `server.py` 编译通过。
- 正则用例：`proxies:weibo` / `proxies:universal` / `abc_123` / 空串 → 放行；含空格 / `*` / `../etc` / 换行 → `400`。

## 关联 issue
- Refs #228（key 注入 + 文档已解决；默认鉴权按上文取舍留待你决定）